### PR TITLE
fix: Address session bug, nav scroll, and add progress UI

### DIFF
--- a/src/components/Flashcard.jsx
+++ b/src/components/Flashcard.jsx
@@ -11,7 +11,7 @@ function shuffleArray(array) {
   return newArray;
 }
 
-function Flashcard({ scenario, onNextScenario, onAnswer, currentScore, totalScenarios, currentIndex, selectedPosition }) {
+function Flashcard({ scenario, onNextScenario, onAnswer, currentScore, totalScenarios, currentIndex, selectedPosition, completedScenarioIds }) {
   const [showExplanation, setShowExplanation] = useState(false);
   const [selectedOption, setSelectedOption] = useState(null);
   const [isTransitioning, setIsTransitioning] = useState(false);
@@ -51,6 +51,7 @@ function Flashcard({ scenario, onNextScenario, onAnswer, currentScore, totalScen
   const { situation, question, explanation, baseRunners, outs, ballLocation } = scenario;
   const isLastQuestion = currentIndex + 1 >= totalScenarios;
   const progress = ((currentIndex + 1) / totalScenarios) * 100;
+  const isCompleted = completedScenarioIds && scenario && completedScenarioIds.includes(scenario.id);
 
   return (
     <div className={`max-w-2xl mx-auto transition-opacity duration-300 ${isTransitioning ? 'opacity-0' : 'opacity-100'}`}>
@@ -82,6 +83,11 @@ function Flashcard({ scenario, onNextScenario, onAnswer, currentScore, totalScen
         
         <div className="mb-6">
           <p className="text-sm text-gray-500 uppercase tracking-wide font-medium mb-1">Situation:</p>
+          {isCompleted && (
+            <span className="inline-block bg-green-100 text-green-700 text-xs font-semibold mr-2 mb-1 px-2.5 py-0.5 rounded-full">
+              ✅ Completed
+            </span>
+          )}
           <p className="text-lg text-gray-800 leading-relaxed">{situation}</p>
         </div>
         <div className="mb-8">

--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -32,8 +32,8 @@ const Navigation = ({ activeView, setActiveView, onResetProgress }) => {
           isOpen ? 'translate-x-0' : 'translate-x-full'
         }`}
       >
-        <div className="pt-16 px-4 pb-16 overflow-y-auto h-full">
-          {/* Added pb-16, overflow-y-auto, and h-full to make the content area scroll if needed, respecting padding. */}
+        <div className="pt-16 px-4 pb-8">
+          {/* Removed h-full and overflow-y-auto to allow content-based height. Adjusted pb to pb-8. */}
           <nav className="space-y-2">
             <button
               onClick={() => handleNavClick('practice')}


### PR DESCRIPTION
This commit includes several fixes and features based on your feedback:

1.  **Bugfix: Session Flow Interruption**:
    - Resolved an issue where completing a scenario in a session would cause the view to incorrectly revert to the 'Start Session' screen.
    - The `useEffect` hook in `App.jsx` that manages scenario lists was made more conditional to prevent it from resetting active session states when `completedScenarioIds` updated.

2.  **Navigation Menu Adjustment**:
    - Modified `src/components/Navigation.jsx` to ensure all navigation items are visible without requiring scrolling on typical screen sizes.
    - Removed `h-full` and `overflow-y-auto` from the inner content wrapper and adjusted bottom padding to allow the menu to size according to its content.

3.  **Visual User Progress Display**:
    - **Progress Summary**: Added a display in `App.jsx` (e.g., "Progress: X / Y scenarios completed") when a position is selected, showing your completion status for that position. This required new state and logic to calculate these counts.
    - **"Completed" Indicator on Flashcard**: The `Flashcard` component now shows a "✅ Completed" badge if the displayed scenario is in the list of `completedScenarioIds`. This is for contexts where you might re-encounter a completed scenario.
    - `completedScenarioIds` is passed down to `Flashcard`, and progress counts are calculated and displayed in `App.jsx`.